### PR TITLE
Fix core dump due to change in access to user data in locator object

### DIFF
--- a/nominatimfilter.py
+++ b/nominatimfilter.py
@@ -117,7 +117,12 @@ class NominatimLocatorFilter(QgsLocatorFilter):
 
     def triggerResult(self, result):
         self.info("UserClick: {}".format(result.displayString))
-        doc = result.userData
+        # Newer Version of PyQT does not expose the .userData (Leading to core dump)
+        # Try via get Function, otherwise access attribute
+        try:
+            doc = result.getUserData()
+        except:
+            doc = result.userData
         extent = doc['boundingbox']
         # "boundingbox": ["52.641015", "52.641115", "5.6737302", "5.6738302"]
         rect = QgsRectangle(float(extent[2]), float(extent[0]), float(extent[3]), float(extent[1]))


### PR DESCRIPTION
It seems that the issue [described here](https://github.com/rduivenvoorde/nominatim_locator_filter/issues/4), which I (and colleagues of mine also experienced on Linux machines is due to the changed access of the user data object. 

This edit gives preference to the use of the access function and falls back on a member access if it is not present.
